### PR TITLE
Add public getters to theme data and brightness

### DIFF
--- a/lib/dynamic_theme.dart
+++ b/lib/dynamic_theme.dart
@@ -36,6 +36,9 @@ class DynamicThemeState extends State<DynamicTheme> {
 
   bool loaded = false;
 
+  get data => _data;
+  get brightness => _brightness;
+
   @override
   void initState() {
     super.initState();


### PR DESCRIPTION

The reason for exposing the currently set theme brightness was to use the value in a checkbox, enabling the user to toggle between a light and a dark theme at runtime.
This works well, but I was forced to wrap my checkbox within a statefull widget to keep track of the selected brightness, because the actual members of `DynamicThemeState` are private. Since that is redundant information, I decided to expose them, without making them publicly settable.

**Commit message:**

The actual theme data and brightness members are still private and can only be modified using setBrightness() and setThemeData().

But making the current values public enables using them for UI toggles like checkboxes, which need to access the current value.
Otherwise, we are forced to introduce further state to keep track of the current brightness.