### PR TITLE
Allow default brightness to be dark

### DIFF
--- a/lib/dynamic_theme.dart
+++ b/lib/dynamic_theme.dart
@@ -86,6 +86,6 @@ class DynamicThemeState extends State<DynamicTheme> {
 
   Future<bool> loadBrightness() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    return (prefs.getBool(_sharedPreferencesKey) ?? widget.defaultBrightness == Brightness.light);
+    return (prefs.getBool(_sharedPreferencesKey) ?? widget.defaultBrightness == Brightness.dark);
   }
 }

--- a/lib/dynamic_theme.dart
+++ b/lib/dynamic_theme.dart
@@ -86,6 +86,6 @@ class DynamicThemeState extends State<DynamicTheme> {
 
   Future<bool> loadBrightness() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    return (prefs.getBool(_sharedPreferencesKey) ?? false);
+    return (prefs.getBool(_sharedPreferencesKey) ?? widget.defaultBrightness == Brightness.light);
   }
 }


### PR DESCRIPTION
If the default brightness is dark, the app will be dark on first load instead of always being light.